### PR TITLE
Fix redundant variable assignment

### DIFF
--- a/pyfe3d/shellprop_utils.py
+++ b/pyfe3d/shellprop_utils.py
@@ -159,7 +159,6 @@ def laminated_plate(stack, plyt=None, laminaprop=None, rho=0., plyts=None,
     plies = []
     prop.h = 0.
     for plyt, laminaprop, thetadeg, rho in zip(plyts, laminaprops, stack, rhos):
-        laminaprop = laminaprop
         ply = Lamina()
         ply.thetadeg = float(thetadeg)
         ply.h = plyt


### PR DESCRIPTION
## Summary
- remove no-op assignment inside `laminated_plate`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556149e3a88320a6eeb2bb6211cab1