### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.runs-on }}
 
     steps:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.runs-on }}
 
     steps:
@@ -44,15 +44,17 @@ jobs:
       run: |
         python3 -m twine upload dist/*.whl
     - name: Build Linux Python wheels, install cibuildwheel
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest'
       run: |
         python -m pip install cibuildwheel==2.19.2
     - name: Build Linux Python wheels
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest'
+      env:
+        CIBW_BUILD: cp${{ matrix.python-version.replace('.', '') }}-manylinux*
       run: |
         python -m cibuildwheel --output-dir dist
     - name: Publish Linux Python wheels
-      if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.12'
+      if: matrix.runs-on == 'ubuntu-latest'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
 Programming Language :: Python :: 3.11
 Programming Language :: Python :: 3.12
+Programming Language :: Python :: 3.13
 License :: OSI Approved :: BSD License
 
 """


### PR DESCRIPTION
## Summary
- list Python 3.13 in package classifiers
- test workflow runs against Python 3.13
- publishing workflow matrix includes Python 3.13
- parallelize Linux wheel builds in release workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68557bde3ba88320bab3961b64cc9948