### PR TITLE
Fix doc typo and validate ply list lengths

### DIFF
--- a/pyfe3d/shellprop_utils.py
+++ b/pyfe3d/shellprop_utils.py
@@ -17,7 +17,7 @@ def read_laminaprop(laminaprop, rho=0):
     ----------
     laminaprop : list or tuple
         For the most general case of tri-axial stress, use a tuple containing
-        the folliwing entries::
+        the following entries::
 
             laminaprop = (e1, e2, nu12, g12, g13, g23, e3, nu13, nu23)
 
@@ -27,7 +27,7 @@ def read_laminaprop(laminaprop, rho=0):
             g = e/(2*(1+nu))
             laminaprop = (e, e, nu, g, g, g, e, nu, nu)
 
-        For othotropic materials with in-plane stresses the user can only
+        For orthotropic materials with in-plane stresses the user can only
         supply::
 
             laminaprop = (e1, e2, nu12, g12, g13, g23)
@@ -41,13 +41,13 @@ def read_laminaprop(laminaprop, rho=0):
         ======  ==============================
         symbol  value
         ======  ==============================
-        e1      Young Module in direction 1
-        e2      Young Module in direction 2
+        e1      Young Modulus in direction 1
+        e2      Young Modulus in direction 2
         nu12    12 Poisson's ratio
         g12     12 Shear Modulus
         g13     13 Shear Modulus
-        g23     13 Shear Modulus
-        e3      Young Module in direction 3
+        g23     23 Shear Modulus
+        e3      Young Modulus in direction 3
         nu13    13 Poisson's ratio
         nu23    23 Poisson's ratio
         ======  ==============================
@@ -156,10 +156,12 @@ def laminated_plate(stack, plyt=None, laminaprop=None, rho=0., plyts=None,
     if rhos is None:
         rhos = [rho for i in stack]
 
+    if not (len(stack) == len(plyts) == len(laminaprops) == len(rhos)):
+        raise ValueError('stack, plyts, laminaprops and rhos must have the same length')
+
     plies = []
     prop.h = 0.
     for plyt, laminaprop, thetadeg, rho in zip(plyts, laminaprops, stack, rhos):
-        laminaprop = laminaprop
         ply = Lamina()
         ply.thetadeg = float(thetadeg)
         ply.h = plyt

--- a/tests/test_shellprop.py
+++ b/tests/test_shellprop.py
@@ -292,3 +292,14 @@ def test_laminate_LP_gradients():
     gradABDE = GradABDE()
     gradABDE.calc_LP_grad(thickness, matlamina, lp)
     print(gradABDE.gradAij)
+
+
+def test_laminated_plate_length_error():
+    lamprop = (71e9, 7e9, 0.28, 7e9, 7e9, 7e9)
+    try:
+        laminated_plate(stack=[0, 45], plyts=[0.000125, 0.000125],
+                        laminaprops=[lamprop], rhos=[0., 0.])
+    except ValueError:
+        pass
+    else:
+        assert False, 'ValueError not raised'


### PR DESCRIPTION
## Summary
- correct docstring for `g23` entry
- validate input list lengths in `laminated_plate`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68556149e3a88320a6eeb2bb6211cab1