### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2024, Saullo G. P. Castro (S.G.P.Castro@tudelft.nl)
+Copyright (c) 2021-2025, Saullo G. P. Castro (S.G.P.Castro@tudelft.nl)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ License
 Distrubuted under the 3-Clause BSD license
 (https://raw.github.com/saullocastro/pyfe3d/main/LICENSE):
 
-    Copyright (c) 2021-2024, Saullo G. P. Castro (S.G.P.Castro@tudelft.nl)
+    Copyright (c) 2021-2025, Saullo G. P. Castro (S.G.P.Castro@tudelft.nl)
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
## Summary
- update copyright notice year to 2025 in license and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685a6d8373e08320bf929833f77ddf92