### PR TITLE
Restrict Linux wheel builds to 64-bit architectures

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -51,7 +51,8 @@ jobs:
     - name: Build Linux Python wheels
       if: matrix.runs-on == 'ubuntu-latest' && matrix.python-version == '3.13'
       env:
-        CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
+        CIBW_BUILD: cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64
+        CIBW_SKIP: "*-manylinux_i686"
       run: |
         python3 -m cibuildwheel --output-dir dist
     - name: Publish Linux Python wheels

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ abstract: >-
   Colab environment.
 message: >-
   Please, cite this software using:
-  Saullo G. P. Castro. (2025). General-purpose finite element solver based on Python and Cython (Version 0.6.1). Zenodo. DOI: https://doi.org/10.5281/zenodo.6573489.
+  Saullo G. P. Castro. (2025). General-purpose finite element solver based on Python and Cython (Version 0.6.2). Zenodo. DOI: https://doi.org/10.5281/zenodo.6573489.
 authors:
   - given-names: Saullo G. P.
     family-names: Castro
@@ -30,5 +30,5 @@ identifiers:
 repository-code: 'https://github.com/saullocastro/pyfe3d'
 url: 'https://saullocastro.github.io/pyfe3d/'
 license: BSD-3-Clause
-version: 0.6.1
+version: 0.6.2
 date-released: '2025-07-23'

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in any platform, including the Google Colab environment.
 Citing this library
 -------------------
 
-Saullo G. P. Castro. (2025). General-purpose finite element solver based on Python and Cython (Version 0.6.1). Zenodo. DOI: https://doi.org/10.5281/zenodo.6573489.
+Saullo G. P. Castro. (2025). General-purpose finite element solver based on Python and Cython (Version 0.6.2). Zenodo. DOI: https://doi.org/10.5281/zenodo.6573489.
 
 
 Documentation

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,7 +18,10 @@ Citing this library
 -------------------
 
 
-Saullo G. P. Castro. (2025). General-purpose finite element solver based on Python and Cython (Version 0.6.1). Zenodo. DOI: https://doi.org/10.5281/zenodo.6573489.
+Saullo G. P. Castro. (2025). General-purpose finite element solver based on Python and Cython (Version 0.6.2). Zenodo. DOI: https://doi.org/10.5281/zenodo.6573489.
+
+Installing this library
+-----------------------
 
 
 Tutorials

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from Cython.Build import cythonize
 
 
 is_released = True
-version = '0.6.1'
+version = '0.6.2'
 year = '2025'
 
 


### PR DESCRIPTION
## Summary
- configure GitHub workflow to build only 64-bit manylinux wheels and skip i686 variants

## Testing
- `pytest -q` *(fails: No module named 'pyfe3d.beamprop')*


------
https://chatgpt.com/codex/tasks/task_e_68b828b40fd083209ebed41cf0df6c34